### PR TITLE
Sometimes when booting the visual camera does not work and an error i…

### DIFF
--- a/Hardware/Cam.h
+++ b/Hardware/Cam.h
@@ -44,9 +44,20 @@ void initCamera() {
 	cam.setCompression(95);
 	//Test if the camera works
 	if (!cam.takePicture()) {
-		drawMessage((char*) "Visual camera is not working!");
+		// try it again after 1 second...
 		delay(1000);
-		setDiagnostic(diag_camera);
+		cam.reset();
+		//Start connection at 115.2k Baud
+		cam.begin(115200);
+		//Set camera compression
+		cam.setCompression(95);
+
+		delay(1000);
+		if (!cam.takePicture()) {
+			drawMessage((char*) "Visual camera is not working!");
+			delay(1000);
+			setDiagnostic(diag_camera);
+		}
 	}
 	//Skip the picture
 	cam.end();


### PR DESCRIPTION
…s reported. When switching the device off and on again it always works.

This Change tries to reinitialze the camera and try accessing it again, so no switching off and on again is required any more.